### PR TITLE
Fixes issues with WP 4.8.3 and ACF Pro 5.6.4 where templates weren't being found and you couldn't remove all the selected templates

### DIFF
--- a/js/field-visibility.js
+++ b/js/field-visibility.js
@@ -51,9 +51,13 @@ jQuery(document).ready(function($) {
 			$("select.acf-flexible-visibility-select").select2();
 
 			$("select.acf-flexible-visibility-select.acf-fv-" + layout_id ).on("change", function(e) {
-				var values = e.val;
+                var values = $(e.target).val();
 
-				$("input.acf-fv-hidden-" + layout_id).val( values.join(",") );
+                if (values) {
+                    values = values.join(',');
+                }
+
+                $("input.acf-fv-hidden-" + layout_id).val(values);
 			});
 		});
 	}

--- a/plugin.php
+++ b/plugin.php
@@ -110,7 +110,7 @@ class ACF_Flexible_Visibility {
 
 		$template = get_page_template_slug( $post_id );
 
-		$content = $wpdb->get_var( $wpdb->prepare( "SELECT post_content FROM $wpdb->posts WHERE post_name = %s", $field["parent"] ));
+        $content = $wpdb->get_var($wpdb->prepare("SELECT post_content FROM $wpdb->posts WHERE ID = %s OR post_name = %s", $field["parent"], $field["parent"]));
 
 		$content = unserialize( $content );
 


### PR DESCRIPTION
Found three issues with the latest versions of WP and ACF Pro.

The first issue was that the values from the select weren't being obtained (this is probably related to the Select2 versions). Changing this to use the `e.target` value fixes the problem.

The second issue was that you couldn't remove all the templates once selected, if you tried to reduce the templates to 0 it would through a JS error due to the `values.join(",")`. Fixed with an if wrapper.

The third issue was that for some reason it wasn't finding the field. Switching it to search the DB via `ID` as well as `post_name` fixed this issue although I suspect `post_name` could be dropped entirely since `$field['parent']` should always be an ID?